### PR TITLE
impls::ops: use `Linear` instead of `Self`

### DIFF
--- a/src/impls/num_traits.rs
+++ b/src/impls/num_traits.rs
@@ -31,6 +31,6 @@ impl<N: Scalar + ComplexField, A: Space, B: Space<Dim = A::Dim>> Inv for Linear<
 {
 	type Output = Linear<N, B, A>;
 	fn inv(self) -> Linear<N, B, A> {
-		Self(self.0.try_inverse().unwrap_or_else(zero))
+		Linear(self.0.try_inverse().unwrap_or_else(zero))
 	}
 }

--- a/src/impls/ops.rs
+++ b/src/impls/ops.rs
@@ -71,7 +71,7 @@ impl<N: Scalar + Zero + One + ClosedAdd + ClosedMul, A: Space, B: Space, C: Spac
 {
 	type Output = Linear<N, A, C>;
 	fn mul(self, other: Linear<N, A, B>) -> Linear<N, A, C> {
-		Self(self.0 * other.0)
+		Linear(self.0 * other.0)
 	}
 }
 


### PR DESCRIPTION
Due to a compiler bug fixed in https://github.com/rust-lang/rust/pull/69340, the crate as-is will stop compiling as per https://crater-reports.s3.amazonaws.com/pr-69340/try%239ff4d07208097950831ed4ea9d76feb1eafc8baa/gh/finegeometer.vector-spaces-rs/log.txt. This PR fixes the issue.